### PR TITLE
moving a piece of code from NewClient into a separate function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
 # Binaries
 *.exe
 *.exe~

--- a/session_save.go
+++ b/session_save.go
@@ -34,6 +34,8 @@ func (m *MTProto) LoadSession() (err error) {
 	if errs.IsNotFound(err) {
 		return err
 	}
+	dry.PanicIfErr(err)
+
 	m.authKey = s.Key
 	m.authKeyHash = s.Hash
 	m.serverSalt = int64(binary.LittleEndian.Uint64(s.Salt)) // СОЛЬ ЭТО LONG

--- a/session_save.go
+++ b/session_save.go
@@ -34,8 +34,6 @@ func (m *MTProto) LoadSession() (err error) {
 	if errs.IsNotFound(err) {
 		return err
 	}
-	dry.PanicIfErr(err)
-
 	m.authKey = s.Key
 	m.authKeyHash = s.Hash
 	m.serverSalt = int64(binary.LittleEndian.Uint64(s.Salt)) // СОЛЬ ЭТО LONG

--- a/telegram/common.go
+++ b/telegram/common.go
@@ -79,14 +79,19 @@ func NewClient(c ClientConfig) (*Client, error) { //nolint: gocritic arg is not 
 
 	client.AddCustomServerRequestHandler(client.handleSpecialRequests())
 
-	resp, err := client.InvokeWithLayer(ApiVersion, &InitConnectionParams{
+	return client, nil
+}
+
+func GetInvokeWithLayer(cl *Client, c ClientConfig, hgc HelpGetConfigParams) (*Config, error) {
+
+	resp, err := cl.InvokeWithLayer(ApiVersion, &InitConnectionParams{
 		ApiID:          int32(c.AppID),
 		DeviceModel:    c.DeviceModel,
 		SystemVersion:  c.SystemVersion,
 		AppVersion:     c.AppVersion,
 		SystemLangCode: "en", // can't be edited, cause docs says that a single possible parameter
 		LangCode:       "en",
-		Query:          &HelpGetConfigParams{},
+		Query:          &hgc,
 	})
 
 	if err != nil {
@@ -98,9 +103,8 @@ func NewClient(c ClientConfig) (*Client, error) { //nolint: gocritic arg is not 
 		return nil, errors.New("got wrong response: " + reflect.TypeOf(resp).String())
 	}
 
-	pp.Println(config)
+	return config, nil
 
-	return client, nil
 }
 
 func (c *Client) handleSpecialRequests() func(interface{}) bool {


### PR DESCRIPTION
moving a piece of code from NewClient into a separate function

example used 

	appConfig := telegram.ClientConfig{
		SessionFile:    ".../session-1.json",
		ServerHost:     config.TestConfiguration,
		PublicKeysFile: ".../public-keys.pem",
		DeviceModel:    "Unknown",
		SystemVersion:  "linux/amd64",
		AppVersion:     "0.1.0",
		AppID:          config.ApiId,
		AppHash:        config.ApiHash,
	}

	client, err := telegram.NewClient(appConfig)
	if err != nil {
		log.Fatal(err)
	}

	configInvokeWithLayer, err := telegram.GetInvokeWithLayer(client, appConfig, telegram.HelpGetConfigParams{})
	if err != nil {
		log.Fatal(err)
	}

	pp.Println(configInvokeWithLayer)