### PR TITLE
Fix ip resolve

### DIFF
--- a/telegram/common.go
+++ b/telegram/common.go
@@ -6,8 +6,10 @@
 package telegram
 
 import (
+	"net"
 	"reflect"
 	"runtime"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/xelaj/errs"
@@ -119,7 +121,7 @@ func NewClient(c ClientConfig) (*Client, error) { //nolint: gocritic arg is not 
 			continue
 		}
 
-		dcList[int(dc.ID)] = dc.IpAddress + ":" + strconv.Itoa(int(dc.Port))
+		dcList[int(dc.ID)] = net.JoinHostPort(dc.IpAddress, strconv.Itoa(int(dc.Port)))
 	}
 	client.SetDCList(dcList)
 	return client, nil


### PR DESCRIPTION
This PR fixed `panic: sending AuthSendCode: recreating connection: can't connect: setup connection: resolving tcp: address 2001:0b28:f23d:f001:0000:0000:0000:000e:443: too many colons in address`